### PR TITLE
Improve description of playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is particularly useful for automatically creating playlists, or transferrin
 
 Install instruction
 ==================
-Create a smart playlist with the name "MusicOnly", which only contains music.
+Create a smart playlist with the name "MusicOnly", which only contains music on your computer ("Media Kind" is "Music" and "Location" is "on this computer").
 Double click autorate.cmd
 
 You can also configure the script to run every day/week when you use the windows task scheduler.


### PR DESCRIPTION
Smart playlist needs to be music _and_ files actually located on the computer.

I spent a bunch of time trying to figure out mysterious errors about missing the "SkippedCount" property, and finally figured out that instead of IITFileOrCDTrack objects, I was sometimes getting IITTrack objects that don't have a Skip Count and the source of those was some "cloud" stuff. Adding Location="on this computer" to the playlist (along with Media Kind=Music) fixed the problem.
